### PR TITLE
New MET and EGFR VUEs and UI updates

### DIFF
--- a/src/components/VUETable.tsx
+++ b/src/components/VUETable.tsx
@@ -61,7 +61,7 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
                             <img alt='reVUE logo' src={vueLogo} width={20} style={{marginBottom:2}} />{' '}
                             Actual Effect
                         </th>
-                        <th>Example Protein Change</th>
+                        <th>Example Revised Protein Change</th>
                         <th>Context & References</th>
                         <th>Usage Example</th>
                     </tr>

--- a/src/components/VUETable.tsx
+++ b/src/components/VUETable.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { VUE } from '../model/VUE';
-import { cbioportalLink, getLinks } from '../utils/VUEUtils';
+import { cbioportalLink, getContextReferences } from '../utils/VUEUtils';
 import "./VUETable.css";
 import vueLogo from "./../images/vue_logo.png";
 import gnLogo from '../images/gn-logo.png';
 import oncokbLogo from '../images/oncokb-logo.png';
 import { DataStore } from '../store/DataStore';
+import { Table } from 'react-bootstrap';
 
 interface IVUETableProps {
     store: DataStore;
@@ -25,12 +26,13 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
 
     const displayData = vueData.map((info) => {
         return (
-            <tr>
+            <tr >
                 <td><Link to={`/vue/${info.hugoGeneSymbol}`}>{info.hugoGeneSymbol}</Link></td>
                 <td>{info.genomicLocationDescription}</td>
                 <td>{info.defaultEffect}</td>
                 <td>{info.comment}</td>
-                <td>{info.context ? `${info.context} (` : ``}{getLinks(info)}{info.context ? `)` : ``}</td>
+                <td>{info.revisedProteinEffects.length > 0 ? info.revisedProteinEffects[0].revisedProteinEffect : ""}</td>
+                <td>{getContextReferences(info)}</td>
                 <td>{info.revisedProteinEffects && (
                     <>
                         <a href={`https://www.genomenexus.org/variant/${info.revisedProteinEffects[0].variant}`} rel="noreferrer" target="_blank">
@@ -48,7 +50,8 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
 
     return (
         <div>
-            <table className="table table-stripeds vue-table">
+            <Table  bordered hover responsive className='vue-table'>
+            {/* <table className="table table-stripeds vue-table"> */}
                 <thead>
                     <tr>
                         <th>Gene</th>
@@ -58,12 +61,13 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
                             <img alt='reVUE logo' src={vueLogo} width={20} style={{marginBottom:2}} />{' '}
                             Actual Effect
                         </th>
+                        <th>Example Protein Change</th>
                         <th>Context & References</th>
                         <th>Usage Example</th>
                     </tr>
                 </thead>
                 <tbody>{displayData}</tbody>
-            </table>
+            </Table>
         </div>
     );
 }

--- a/src/components/VUETable.tsx
+++ b/src/components/VUETable.tsx
@@ -26,8 +26,8 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
     const displayData = vueData.map((info) => {
         return (
             <tr>
-                <td>{info.hugoGeneSymbol}</td>
-                <td>{info.genomicLocationDescription}{info.revisedProteinEffects.length > 1 && <Link style={{ marginLeft: '10px' }} to={`/vue/${info.hugoGeneSymbol}`}>View All</Link>}</td>
+                <td><Link to={`/vue/${info.hugoGeneSymbol}`}>{info.hugoGeneSymbol}</Link></td>
+                <td>{info.genomicLocationDescription}</td>
                 <td>{info.defaultEffect}</td>
                 <td>{info.comment}</td>
                 <td>{info.context ? `${info.context} (` : ``}{getLinks(info)}{info.context ? `)` : ``}</td>

--- a/src/model/VUE.ts
+++ b/src/model/VUE.ts
@@ -5,20 +5,29 @@ export type VUE = {
     defaultEffect: string;
     comment: string;
     context: string;
-    revisedProteinEffects: {
-        variant: string;
-        genomicLocation: string;
-        transcriptId: string;
-        vepPredictedProteinEffect: string;
-        vepPredictedVariantClassification: string;
-        revisedProteinEffect: string;
-        revisedVariantClassification: string;
-        mutationOrigin: string,
-        pubmedId: number;
-        referenceText: string;
+    revisedProteinEffects: RevisedProteinEffect[];
+};
+
+export type RevisedProteinEffect = {
+    variant: string;
+    genomicLocation: string;
+    transcriptId: string;
+    vepPredictedProteinEffect: string;
+    vepPredictedVariantClassification: string;
+    revisedProteinEffect: string;
+    revisedVariantClassification: string;
+    mutationOrigin: string,
+    pubmedId: number;
+    referenceText: string;
+    germlineVariantsCount: number;
+    somaticVariantsCount: number;
+    unknownMutationStatusVariantsCount: number;
+    confirmed: boolean;
+    counts: {[cohort: string]: {
         germlineVariantsCount: number;
         somaticVariantsCount: number;
-        unknownMutationStatusVariantsCount: number;
-        confirmed: boolean;
-    }[];
-};
+        unknownVariantsCount: number;
+        totalSampleCount: number;
+        geneSampleCount: number;
+    }}
+}

--- a/src/model/VUE.ts
+++ b/src/model/VUE.ts
@@ -16,6 +16,9 @@ export type VUE = {
         mutationOrigin: string,
         pubmedId: number;
         referenceText: string;
+        germlineVariantsCount: number;
+        somaticVariantsCount: number;
+        unknownMutationStatusVariantsCount: number;
         confirmed: boolean;
     }[];
 };

--- a/src/pages/Variants.css
+++ b/src/pages/Variants.css
@@ -26,3 +26,9 @@ table td, table th {
   padding: 5px;
 }
 
+.tooltip > .tooltip-inner {
+  background-color: white; 
+  color: black; 
+  border-color: black;
+  border: 1px solid black;
+}

--- a/src/pages/Variants.css
+++ b/src/pages/Variants.css
@@ -32,3 +32,8 @@ table td, table th {
   border-color: black;
   border: 1px solid black;
 }
+
+.footer {
+  margin-top: 20px;
+  text-align: left;
+}

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { RevisedProteinEffect, VUE } from '../model/VUE';
 import { DataStore } from '../store/DataStore';
-import { cbioportalLink, getLinksFromVue, revisedProteinEffectSortingFn, getContextReferences } from '../utils/VUEUtils';
+import { cbioportalLink, revisedProteinEffectSortingFn, getContextReferences } from '../utils/VUEUtils';
 import { Container, OverlayTrigger, Table, Tooltip } from 'react-bootstrap';
 import './Variants.css';
 import gnLogo from '../images/gn-logo.png';

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { RevisedProteinEffect, VUE } from '../model/VUE';
 import { DataStore } from '../store/DataStore';
-import { cbioportalLink, getLinks } from '../utils/VUEUtils';
+import { cbioportalLink, getLinksFromVue, revisedProteinEffectSortingFn, getContextReferences } from '../utils/VUEUtils';
 import { Container, OverlayTrigger, Table, Tooltip } from 'react-bootstrap';
 import './Variants.css';
 import gnLogo from '../images/gn-logo.png';
@@ -47,7 +47,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
     if (variantData && variantData.revisedProteinEffects.length > 0) {
         const displayData = 
             variantData.revisedProteinEffects
-            .sort((a, b) => (b.counts["mskimpact"].germlineVariantsCount + b.counts["mskimpact"].somaticVariantsCount + b.counts["mskimpact"].unknownVariantsCount) - (a.counts["mskimpact"].germlineVariantsCount + a.counts["mskimpact"].somaticVariantsCount + a.counts["mskimpact"].unknownVariantsCount))
+            .sort(revisedProteinEffectSortingFn)
             .map((i) => {
                 updateCount(i);
                 return (
@@ -58,13 +58,8 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                         <td>{i.vepPredictedVariantClassification}</td>
                         <td>{i.revisedProteinEffect}</td>
                         <td>{i.revisedVariantClassification}</td>
-                        <td>{i.mutationOrigin}</td>
-                        <td>{`${i.counts["mskimpact"]?.germlineVariantsCount}${` / `}${i.counts["mskimpact"]?.somaticVariantsCount}${` / `}${i.counts["mskimpact"]?.unknownVariantsCount}`}</td>
-                        <td>{`${i.counts["tcga"]?.germlineVariantsCount}${` / `}${i.counts["tcga"].somaticVariantsCount}${` / `}${i.counts["tcga"].unknownVariantsCount}`}</td>
-                        <td>{i.pubmedId === 0 ? <>{i.referenceText}</> : <a href={`https://pubmed.ncbi.nlm.nih.gov/${i.pubmedId}/`} rel="noreferrer" target="_blank">
-                            {i.referenceText}
-                            </a>}
-                        </td>
+                        <td>{i.counts["mskimpact"].somaticVariantsCount + i.counts["mskimpact"].unknownVariantsCount}</td>
+                        <td>{i.counts["tcga"].somaticVariantsCount + i.counts["tcga"].unknownVariantsCount}</td>
                         <td>
                             <a href={`https://www.genomenexus.org/variant/${i.variant}`} rel="noreferrer" target="_blank">
                                 <img src={gnLogo} alt="gn-logo" style={{height: 20, marginRight: 10}} />
@@ -73,6 +68,9 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                                 <img src={oncokbLogo} alt="oncokb-logo" style={{height: 16, marginRight: 10}} />
                             </a>
                             {cbioportalLink(i.revisedProteinEffect.substring(2), gene)}
+                        </td>
+                        <td>
+                            {getContextReferences(variantData, true)}
                         </td>
                     </tr>
                 );
@@ -83,7 +81,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                 <div className="title-container">
                 <h1 className="title">{variantData.hugoGeneSymbol}</h1>
                 <h2 className="subtitle" style={{fontWeight: "bold"}}>Actual Effect: <span style={{fontWeight: "normal"}}>{variantData.comment}</span></h2>
-                <h3 className="subtitle" style={{fontWeight: "bold"}}>Context & References: <span style={{fontWeight: "normal"}}>{variantData.context}{' '}{getLinks(variantData)}</span></h3>
+                <h3 className="subtitle" style={{fontWeight: "bold"}}>Context: <span style={{fontWeight: "normal"}}>{variantData.context}</span></h3>
                 </div>
                 <Table striped bordered hover responsive>
                     <thead>
@@ -94,8 +92,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                             <th>Predicted Variant Classification by VEP</th>
                             <th>Revised Protein Effect</th>
                             <th>Revised Variant Classification</th>
-                            <th>Mutation Status</th>
-                            <th>MSK-IMPACT Variants Count (Germline/Somatic/Unknown)
+                            <th>MSK-IMPACT Variants Count
                                 <OverlayTrigger
                                     placement="right"
                                     delay={{ show: 250, hide: 400 }}
@@ -106,10 +103,10 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                                             {variantData.hugoGeneSymbol} sample count: {mskGeneSampleCount}
                                         </Tooltip>}
                                     >
-                                    <i className={'fa fa-info-circle'} />
+                                    <i className={'fa fa-info-circle'} style={{marginLeft: 5}} />
                                 </OverlayTrigger>
                             </th>
-                            <th>TCGA Pan-Cancer Atlas Variants Count (Germline/Somatic/Unknown)
+                            <th>TCGA Pan-Cancer Atlas Variants Count
                                 <OverlayTrigger
                                     placement="right"
                                     delay={{ show: 250, hide: 400 }}
@@ -120,15 +117,16 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                                             {variantData.hugoGeneSymbol} sample count: {tcgaGeneSampleCount}
                                         </Tooltip>}
                                     >
-                                    <i className={'fa fa-info-circle'} />
+                                    <i className={'fa fa-info-circle'} style={{marginLeft: 5}} />
                                 </OverlayTrigger>
                             </th>
-                            <th>Context & References</th>
                             <th>Linkouts</th>
+                            <th>References</th>
                         </tr>
                     </thead>
                     <tbody>{displayData}</tbody>
                 </Table>
+                <div className="footer">All positions are in hg19</div>
             </Container>
         );
     }

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -41,9 +41,9 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                         <td>{i.revisedProteinEffect}</td>
                         <td>{i.revisedVariantClassification}</td>
                         <td>{i.mutationOrigin}</td>
-                        <td><a href={`https://pubmed.ncbi.nlm.nih.gov/${i.pubmedId}/`} rel="noreferrer" target="_blank">
+                        <td>{i.pubmedId === 0 ? <>{i.referenceText}</> : <a href={`https://pubmed.ncbi.nlm.nih.gov/${i.pubmedId}/`} rel="noreferrer" target="_blank">
                             {i.referenceText}
-                            </a>
+                            </a>}
                         </td>
                         <td>
                             <a href={`https://www.genomenexus.org/variant/${i.variant}`} rel="noreferrer" target="_blank">
@@ -62,8 +62,8 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
             <Container className="gene-page">
                 <div className="title-container">
                 <h1 className="title">{variantData.hugoGeneSymbol}</h1>
-                <h2 className="subtitle">Actual Effect: {variantData.comment}</h2>
-                <h3 className="subtitle">Context & References: {variantData.context}{' '}{getLinks(variantData)}</h3>
+                <h2 className="subtitle" style={{fontWeight: "bold"}}>Actual Effect: <span style={{fontWeight: "normal"}}>{variantData.comment}</span></h2>
+                <h3 className="subtitle" style={{fontWeight: "bold"}}>Context & References: <span style={{fontWeight: "normal"}}>{variantData.context}{' '}{getLinks(variantData)}</span></h3>
                 </div>
                 <Table striped bordered hover>
                     <thead>

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { RevisedProteinEffect, VUE } from '../model/VUE';
 import { DataStore } from '../store/DataStore';
-import { cbioportalLink, revisedProteinEffectSortingFn, getContextReferences } from '../utils/VUEUtils';
+import { cbioportalLink, revisedProteinEffectSortingFn } from '../utils/VUEUtils';
 import { Container, OverlayTrigger, Table, Tooltip } from 'react-bootstrap';
 import './Variants.css';
 import gnLogo from '../images/gn-logo.png';
@@ -69,8 +69,9 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                             </a>
                             {cbioportalLink(i.revisedProteinEffect.substring(2), gene)}
                         </td>
-                        <td>
-                            {getContextReferences(variantData, true)}
+                        <td>{i.pubmedId === 0 ? <>{i.referenceText}</> : <a href={`https://pubmed.ncbi.nlm.nih.gov/${i.pubmedId}/`} rel="noreferrer" target="_blank">
+                            {i.referenceText}
+                            </a>}
                         </td>
                     </tr>
                 );

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { VUE } from '../model/VUE';
 import { DataStore } from '../store/DataStore';
 import { cbioportalLink, getLinks } from '../utils/VUEUtils';
-import { Container, Table } from 'react-bootstrap';
+import { Container, OverlayTrigger, Table, Tooltip } from 'react-bootstrap';
 import './Variants.css';
 import gnLogo from '../images/gn-logo.png';
 import oncokbLogo from '../images/oncokb-logo.png';
@@ -41,6 +41,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                         <td>{i.revisedProteinEffect}</td>
                         <td>{i.revisedVariantClassification}</td>
                         <td>{i.mutationOrigin}</td>
+                        <td>{`${i.germlineVariantsCount}${` / `}${i.somaticVariantsCount}${` / `}${i.unknownMutationStatusVariantsCount}`}</td>
                         <td>{i.pubmedId === 0 ? <>{i.referenceText}</> : <a href={`https://pubmed.ncbi.nlm.nih.gov/${i.pubmedId}/`} rel="noreferrer" target="_blank">
                             {i.referenceText}
                             </a>}
@@ -65,7 +66,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                 <h2 className="subtitle" style={{fontWeight: "bold"}}>Actual Effect: <span style={{fontWeight: "normal"}}>{variantData.comment}</span></h2>
                 <h3 className="subtitle" style={{fontWeight: "bold"}}>Context & References: <span style={{fontWeight: "normal"}}>{variantData.context}{' '}{getLinks(variantData)}</span></h3>
                 </div>
-                <Table striped bordered hover>
+                <Table striped bordered hover responsive>
                     <thead>
                         <tr>
                         <   th>Variant <i className="fa fa-external-link" /></th>
@@ -75,6 +76,19 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                             <th>Revised Protein Effect</th>
                             <th>Revised Variant Classification</th>
                             <th>Mutation Origin</th>
+                            <th>Variants Count (Germline/Somatic/Unknown)
+                                <OverlayTrigger
+                                    placement="right"
+                                    delay={{ show: 250, hide: 400 }}
+                                    overlay={
+                                        <Tooltip color='light' id="button-tooltip">
+                                            Counting from MSK-IMPACT and TCGA Pan-Cancer Atlas
+                                        </Tooltip>}
+                                    >
+                                    <i className={'fa fa-info-circle'} />
+                                </OverlayTrigger>
+
+                            </th>
                             <th>Context & References</th>
                             <th>Linkouts</th>
                         </tr>

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -65,10 +65,6 @@ export const getLinks = (references: Reference[]) => {
     return links;
 }
 
-export const getLinksFromVue = (vue: VUE) => {
-    return getLinks(getReferencesText(vue));
-}
-
 export const getContextReferences = (vue: VUE, referenceOnly?: boolean) => {
     let context = vue.context || "";
     let referencesWithoutLinkTextList = [];

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -22,7 +22,7 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/166fed92151ed09051f8cb10e58edc40ae1cd2a5/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/main/VUEs.json'
         );
         const vues: VUE[] = await response.json();
         // Sort revisedProteinEffects by counts
@@ -92,7 +92,7 @@ export const getContextReferences = (vue: VUE, referenceOnly?: boolean) => {
                 {!referenceOnly && `${context} (`}
                 {referencesWithoutLinkText}
                 {getLinks(referencesWithLink)}
-                {`)`}
+                {!referenceOnly &&`)`}
             </>
         );
     } else {

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -1,5 +1,10 @@
-import { VUE } from "../model/VUE";
+import { RevisedProteinEffect, VUE } from "../model/VUE";
 import cbioportalLogo from "../images/cbioportal-logo.png";
+
+export type Reference = {
+    referenceText: string;
+    pubmedId: number;
+};
 
 export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
     // for now only show APC and CTNNB1
@@ -17,18 +22,22 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/0424bd06301f96480484956db34f76a0ce182376/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/166fed92151ed09051f8cb10e58edc40ae1cd2a5/VUEs.json'
         );
-        const json = await response.json();
-        return json;
+        const vues: VUE[] = await response.json();
+        // Sort revisedProteinEffects by counts
+        for (const vue of vues) {
+            vue.revisedProteinEffects = vue.revisedProteinEffects.sort(revisedProteinEffectSortingFn);
+        }
+        return vues;
     } catch (error) {
         console.error('Error fetching JSON:', error);
         return [];
     }
 };
 
-export const getLinks = (vue: VUE) => {
-    const uniqueReferences: { referenceText: string, pubmedId: number }[] = [];
+export const getReferencesText = (vue: VUE) => {
+    const uniqueReferences: Reference[] = [];
     vue.revisedProteinEffects.forEach(v => {
         let i = uniqueReferences.findIndex(ref => (ref.referenceText === v.referenceText && ref.pubmedId === v.pubmedId))
         if (i === -1) {
@@ -38,17 +47,66 @@ export const getLinks = (vue: VUE) => {
             });
         }
     })
+    return uniqueReferences;
+}
 
-    const links = uniqueReferences.map((reference, i) =>{
+export const getLinks = (references: Reference[]) => {
+    const links = references.map((reference, i) =>{
         // pubmedId = 0 means this variant is reported by users and does not have any paper as reference
         return reference.pubmedId === 0 ? <>{reference.referenceText}</> :
             <>
                 <a href={`https://pubmed.ncbi.nlm.nih.gov/${reference.pubmedId}/`} rel="noreferrer" target="_blank">
                     {reference.referenceText}
                 </a>
-                {(i !== uniqueReferences.length - 1) && '; '}
+                {(i !== references.length - 1) && '; '}
             </> 
     } )
 
     return links;
 }
+
+export const getLinksFromVue = (vue: VUE) => {
+    return getLinks(getReferencesText(vue));
+}
+
+export const getContextReferences = (vue: VUE, referenceOnly?: boolean) => {
+    let context = vue.context || "";
+    let referencesWithoutLinkTextList = [];
+    const referencesWithLink = [];
+    for (const reference of getReferencesText(vue)) {
+        if (reference.pubmedId === 0) {
+            referencesWithoutLinkTextList.push(reference.referenceText);
+        } else {
+            const splitedReferenceText = reference.referenceText.split(';');
+            if (splitedReferenceText.length === 2) {
+                referencesWithoutLinkTextList.push(splitedReferenceText[0]);
+                referencesWithLink.push({
+                    referenceText: splitedReferenceText[1],
+                    pubmedId: reference.pubmedId
+                })
+            } else {
+                referencesWithLink.push(reference);
+            }
+        }
+    }
+    const referencesWithoutLinkText = referencesWithoutLinkTextList.length > 0 ? referencesWithoutLinkTextList.join("; ") + "; ": "";
+    if (context) {
+        return (
+            <>
+                {!referenceOnly && `${context} (`}
+                {referencesWithoutLinkText}
+                {getLinks(referencesWithLink)}
+                {`)`}
+            </>
+        );
+    } else {
+        return (
+            <>
+                {referencesWithoutLinkText}
+                {getLinks(referencesWithLink)}
+            </>
+        );
+    }
+}
+
+export const revisedProteinEffectSortingFn = (a: RevisedProteinEffect, b: RevisedProteinEffect) => {return (b.counts["mskimpact"].somaticVariantsCount + b.counts["mskimpact"].unknownVariantsCount) - (a.counts["mskimpact"].somaticVariantsCount + a.counts["mskimpact"].unknownVariantsCount)};

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -17,7 +17,7 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/3debd1e24e403a233bb496b14dd4cdf010ff9d33/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/ddcb06f417209eb6cf602dd1291a4bb605b4bd6f/VUEs.json'
         );
         const json = await response.json();
         return json;

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -17,7 +17,7 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/a2960861e2b559772387b0952985f0fa325bed47/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/0424bd06301f96480484956db34f76a0ce182376/VUEs.json'
         );
         const json = await response.json();
         return json;

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -17,7 +17,7 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/ddcb06f417209eb6cf602dd1291a4bb605b4bd6f/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/a2960861e2b559772387b0952985f0fa325bed47/VUEs.json'
         );
         const json = await response.json();
         return json;

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -17,7 +17,7 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/main/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/3debd1e24e403a233bb496b14dd4cdf010ff9d33/VUEs.json'
         );
         const json = await response.json();
         return json;
@@ -39,16 +39,16 @@ export const getLinks = (vue: VUE) => {
         }
     })
 
-    const links = uniqueReferences.map((reference, i) => 
-        (
+    const links = uniqueReferences.map((reference, i) =>{
+        // pubmedId = 0 means this variant is reported by users and does not have any paper as reference
+        return reference.pubmedId === 0 ? <>{reference.referenceText}</> :
             <>
                 <a href={`https://pubmed.ncbi.nlm.nih.gov/${reference.pubmedId}/`} rel="noreferrer" target="_blank">
                     {reference.referenceText}
                 </a>
-                {(i !== uniqueReferences.length - 1) && ', '}
-            </>
-        )
-    )
+                {(i !== uniqueReferences.length - 1) && '; '}
+            </> 
+    } )
 
     return links;
 }


### PR DESCRIPTION
- [x] Add new MET and EGFR VUEs
- [x]  Home page:
    - [x]  Add new column "Example protein change", choose the first variant revised protein change value
    - [x]  Add “(Unpublished)” for mutations that we have from Archer in the reference column, remove "using Archer", separate by ;
- [x] Add manuscript for EGFR
- [x]  Remove Mutation status column (causes misunderstanding that all variants in TCGA and MSK-IMPACT are germline or somatic)
- [x]  On gene page at the bottom list that all positions are in hg19
- [x]  keep Context only on header
- [x]  Table column only keep reference column, put it in the last
- [x]  Remove unknown category and add into somatic
- [x]  Only show somatic counts (somatic + unknown), sort table