### PR TITLE
Add VUEs count on home page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -33,8 +33,9 @@ const Home: React.FC<IHomeProps> = ( props ) => {
                     <p className="lead">A Repository for Variants with Unexpected Effects (VUE) in Cancer</p> 
                     <span>A curated database of known protein effects for those variants that aren't as easily predicted by conventional annotation tools.</span>
                     <hr className="my-4" />
-                    <div>Total genes:{` `}{totalGenes}</div>
-                    <div>Curated VUEs:{` `}{curatedVUEs}</div>
+                    <span>Total genes:{` `}{totalGenes}</span>
+                    <span style={{marginLeft: 50}}>Curated VUEs:{` `}{curatedVUEs}</span>
+                    <span style={{marginLeft: 50}}>VUEs with therapeutic implications: 1</span>
                 </div>
                 <p className='text-left'>
                     <VUETable store={props.store}/>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,6 @@ const Home: React.FC<IHomeProps> = ( props ) => {
                     <hr className="my-4" />
                     <span>Total genes:{` `}{totalGenes}</span>
                     <span style={{marginLeft: 50}}>Curated VUEs:{` `}{curatedVUEs}</span>
-                    <span style={{marginLeft: 50}}>VUEs with therapeutic implications: 1</span>
                 </div>
                 <p className='text-left'>
                     <VUETable store={props.store}/>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,10 +8,21 @@ interface IHomeProps {
     store: DataStore;
 }
 
-class Home extends React.Component<IHomeProps>
-{
-    public render()
-    {
+const Home: React.FC<IHomeProps> = ( props ) => {
+    const [totalGenes, setTotalGenes] = React.useState(0);
+    const [curatedVUEs, setCuratedVUEs] = React.useState(0);
+
+    React.useEffect(() => {
+        props.store.data.then(vueArray => {
+            setTotalGenes(vueArray.length);
+            let totalRevisedProteinEffects = 0;
+            vueArray.forEach(vue => {
+                totalRevisedProteinEffects += vue.revisedProteinEffects.length;
+            });
+            setCuratedVUEs(totalRevisedProteinEffects);
+        });
+    }, [props.store]);
+
         return (
             <React.Fragment>
                 <div className="jumbotron jumbotron-fluid">
@@ -19,16 +30,17 @@ class Home extends React.Component<IHomeProps>
                         <img alt='reVUE logo' src={vueLogo} width={60} style={{paddingRight:10}}/>
                         reVUE
                     </h1>
-                    <p className="lead">A Repository for Variants with Unexpected Effects (VUE) in Cancer</p>
-                    <hr className="my-4" />
+                    <p className="lead">A Repository for Variants with Unexpected Effects (VUE) in Cancer</p> 
                     <span>A curated database of known protein effects for those variants that aren't as easily predicted by conventional annotation tools.</span>
+                    <hr className="my-4" />
+                    <div>Total genes:{` `}{totalGenes}</div>
+                    <div>Curated VUEs:{` `}{curatedVUEs}</div>
                 </div>
                 <p className='text-left'>
-                    <VUETable store={this.props.store}/>
+                    <VUETable store={props.store}/>
                 </p>
             </React.Fragment>
         );
-    }
 }
 
 export default Home;


### PR DESCRIPTION
Fix: https://github.com/knowledgesystems/reVUE/issues/10
<img width="1005" alt="image" src="https://github.com/knowledgesystems/reVUE/assets/16869603/0c076316-58c9-48c0-a65b-8b1b1abf8aa4">

Add total genes and curated VUEs count on home page