### PR TITLE
Replace genomic location column to variants count on homepage

### DIFF
--- a/src/components/VUETable.tsx
+++ b/src/components/VUETable.tsx
@@ -30,7 +30,7 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
         return (
             <tr >
                 <td><Link to={`/vue/${info.hugoGeneSymbol}`}>{info.hugoGeneSymbol}</Link></td>
-                <td>{info.genomicLocationDescription}</td>
+                <td>{info.revisedProteinEffects.length}</td>
                 <td>{info.defaultEffect}</td>
                 <td>{info.comment}</td>
                 <td>
@@ -71,7 +71,7 @@ export const VUETable: React.FC<IVUETableProps> = (props) => {
                 <thead>
                     <tr>
                         <th>Gene</th>
-                        <th>Genomic Location</th>
+                        <th>Variants Count</th>
                         <th>Predicted Effect</th>
                         <th>
                             <img alt='reVUE logo' src={vueLogo} width={20} style={{marginBottom:2}} />{' '}


### PR DESCRIPTION
Previous:
<img width="1726" alt="image" src="https://github.com/knowledgesystems/reVUE/assets/16869603/ef691f70-7272-41a6-8850-073d41476ff2">
Now:
<img width="1721" alt="image" src="https://github.com/knowledgesystems/reVUE/assets/16869603/6fceeaf0-0934-4b76-9ae7-2187b17a3156">
