### PR TITLE
Add separate columns for 'Oncogenic'  and 'Therapeutic Level' 

### DIFF
--- a/src/components/VUETable.tsx
+++ b/src/components/VUETable.tsx
@@ -19,7 +19,7 @@ const therapeuticLevelSort = (rowA: Row<VUE>, rowB: Row<VUE>, columnId: string) 
     const valueA = rowA.values[columnId];
     const valueB = rowB.values[columnId];
 
-    const therapeuticLevelOrder = ['LEVEL_1', 'LEVEL_2', 'LEVEL_3', 'LEVEL_4', 'Oncogenic'];
+    const therapeuticLevelOrder = ['LEVEL_1', 'LEVEL_2', 'LEVEL_3', 'LEVEL_4', 'None'];
 
     const indexA = therapeuticLevelOrder.indexOf(valueA);
     const indexB = therapeuticLevelOrder.indexOf(valueB);

--- a/src/components/VUETable.tsx
+++ b/src/components/VUETable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { VUE } from '../model/VUE';
-import { cbioportalLink, extractContextAndReferences, getHighestTherapeuticLevel, renderContextAndReferences } from '../utils/VUEUtils';
+import { cbioportalLink, extractContextAndReferences, getHighestOncogenicLevel, getHighestTherapeuticLevel, renderContextAndReferences } from '../utils/VUEUtils';
 import vueLogo from "./../images/vue_logo.png";
 import gnLogo from '../images/gn-logo.png';
 import oncokbLogo from '../images/oncokb-logo.png';
@@ -99,6 +99,11 @@ const VUETable: React.FC<IVUETableProps> = (props) => {
             sortType: therapeuticLevelSort,
             width: "10%"
         },
+                {
+            Header: 'Oncogenic',
+            accessor: (row: VUE) => getHighestOncogenicLevel(row),
+            width: "10%"
+        },
         {
             Header: 'Predicted Effect',
             accessor: 'defaultEffect',
@@ -145,10 +150,16 @@ const VUETable: React.FC<IVUETableProps> = (props) => {
                             <a href={`https://www.genomenexus.org/variant/${row.revisedProteinEffects[0].variant}`} rel="noreferrer" target="_blank">
                                 <img src={gnLogo} alt="gn-logo" style={{ height: 20, marginRight: 10 }} />
                             </a>
-                            <a href={`https://www.oncokb.org/hgvsg/${row.revisedProteinEffects[0].variant}`} rel="noreferrer" target="_blank">
-                                <img src={oncokbLogo} alt="oncokb-logo" style={{ height: 16, marginRight: 10 }} />
-                            </a>
-                            {cbioportalLink(row.revisedProteinEffects[0].revisedProteinEffect.substring(2), row.hugoGeneSymbol)}
+                            {row.revisedProteinEffects[0] && (
+                                <>
+                                    <a href={`https://www.oncokb.org/hgvsg/${row.revisedProteinEffects[0].variant}`} rel="noreferrer" target="_blank">
+                                        <img src={oncokbLogo} alt="oncokb-logo" style={{ height: 16, marginRight: 10 }} />
+                                    </a>
+                                    {row.revisedProteinEffects[0].revisedProteinEffect &&
+                                        cbioportalLink(row.revisedProteinEffects[0].revisedProteinEffect.substring(2), row.hugoGeneSymbol)
+                                    }
+                                </>
+                            )}
                         </>
                     )}
                 </>

--- a/src/model/VUE.ts
+++ b/src/model/VUE.ts
@@ -34,6 +34,7 @@ export type RevisedProteinEffect = {
         unknownVariantsCountByCancerType: {};
     }};
     therapeuticLevel: string;
+    oncogenic: string;
 }
 
 export type Reference = {

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -54,7 +54,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                         <td>{i.vepPredictedVariantClassification}</td>
                         <td>{i.revisedProteinEffect}</td>
                         <td>{i.revisedVariantClassification}</td>
-                        <td>{i.therapeuticLevel || "Oncogenic"}</td>
+                        <td>{i.therapeuticLevel || "None"}</td>
                         <td>{i.counts["mskimpact"].somaticVariantsCount + 
                              i.counts["mskimpact"].unknownVariantsCount + 
                              i.counts["mskimpact"].germlineVariantsCount +

--- a/src/pages/Variants.tsx
+++ b/src/pages/Variants.tsx
@@ -55,6 +55,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                         <td>{i.revisedProteinEffect}</td>
                         <td>{i.revisedVariantClassification}</td>
                         <td>{i.therapeuticLevel || "None"}</td>
+                        <td>{i.oncogenic || "None"}</td>
                         <td>{i.counts["mskimpact"].somaticVariantsCount + 
                              i.counts["mskimpact"].unknownVariantsCount + 
                              i.counts["mskimpact"].germlineVariantsCount +
@@ -69,7 +70,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                             <a href={`https://www.oncokb.org/hgvsg/${i.variant}`} rel="noreferrer" target="_blank">
                                 <img src={oncokbLogo} alt="oncokb-logo" style={{height: 16, marginRight: 10}} />
                             </a>
-                            {cbioportalLink(i.revisedProteinEffect.substring(2), gene)}
+                            {i.revisedProteinEffect && cbioportalLink(i.revisedProteinEffect.substring(2), gene)}
                         </td>
                         <td>
                             {i.references.map((ref, index) => (
@@ -133,6 +134,7 @@ export const Variants: React.FC<IVariantsProps> = (props) => {
                                 </OverlayTrigger>
                             </th>
                             <th>Therapeutic Level</th>
+                            <th>Oncogenic</th>
                             <th>MSK-IMPACT Variants Count
                                 <OverlayTrigger
                                     placement="right"

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -22,7 +22,7 @@ export const cbioportalLink = (proteinChange: string, gene?: string, ) => {
 export const fetchVueData = async (): Promise<VUE[]> => {
     try {
         const response = await fetch(
-            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/b49aac76e5e27d94dc059b67f22556c2792d31ad/VUEs.json'
+            'https://raw.githubusercontent.com/knowledgesystems/reVUE-data/e749cb7c9d64cd7c3e1a792744e7c781b73f0685/generated/VUEs.json'
         );
         let vues: VUE[] = await response.json();
         // Sort VUEs by genes in alphabetical order
@@ -122,4 +122,34 @@ export const getHighestTherapeuticLevel = (vue: VUE) => {
     });
     return highestTherapeuticLevel;
 }
+
+export const getHighestOncogenicLevel = (vue: VUE) => {
+    // Define the ranking: lower index = higher oncogenicity
+    const ranking: Record<string, number> = {
+        "Oncogenic": 1,
+        "Likely Oncogenic": 2,
+        "Predicted Oncogenic": 3,
+        "Resistance": 4,
+        "Likely Neutral": 5,
+        "Predicted Neutral": 6,
+        "Inconclusive": 7,
+        "Unknown": 8,
+        "None": 9
+    };
+
+    let highestOncogenicLevel = "None";
+    let bestRank = ranking["None"];
+
+    vue.revisedProteinEffects?.forEach(e => {
+        const level = e.oncogenic ?? "None";
+        const rank = ranking[level] ?? ranking["None"];
+        if (rank < bestRank) {
+            bestRank = rank;
+            highestOncogenicLevel = level;
+        }
+    });
+
+    return highestOncogenicLevel;
+}
+
 export const revisedProteinEffectSortingFn = (a: RevisedProteinEffect, b: RevisedProteinEffect) => {return (b.counts["mskimpact"].somaticVariantsCount + b.counts["mskimpact"].unknownVariantsCount) - (a.counts["mskimpact"].somaticVariantsCount + a.counts["mskimpact"].unknownVariantsCount)};

--- a/src/utils/VUEUtils.tsx
+++ b/src/utils/VUEUtils.tsx
@@ -112,7 +112,7 @@ export const renderContextAndReferences = (contextAndReferences: ContextAndRefer
 
 
 export const getHighestTherapeuticLevel = (vue: VUE) => {
-    let highestTherapeuticLevel = "Oncogenic";
+    let highestTherapeuticLevel = "None";
     let highestLevel = Infinity;
     vue.revisedProteinEffects?.forEach(e => {
         if (e.therapeuticLevel && parseInt(e.therapeuticLevel.split('_')[1]) < highestLevel) {


### PR DESCRIPTION
Previous
<img width="1481" height="492" alt="image" src="https://github.com/user-attachments/assets/df3539d2-9fbf-40a2-8d3f-b1eb04407c3f" />
New
Example: https://deploy-preview-23--cancerrevue.netlify.app/vue/ATM
<img width="1456" height="259" alt="image" src="https://github.com/user-attachments/assets/d148c4a9-6f5f-40ac-a814-9e6dde4520d0" />
<img width="1423" height="314" alt="image" src="https://github.com/user-attachments/assets/5e348a8b-40ac-43fa-923c-7d9412e792b2" />


Add a new Oncogenic column to show variant oncogenicity from OncoKB.